### PR TITLE
fix: cran warnings about packages

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,1 +1,2 @@
 ^.github$
+cran-comments.md

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,8 +16,7 @@ Authors@R: c(
 Maintainer: Mihail Anton <mihail.anton@chalmers.se>
 Depends: R (>= 3.2.0), Matrix, lattice
 Imports: methods
-Suggests: glpkAPI (>= 1.2.8), cplexAPI (>= 1.2.4), clpAPI (>= 1.2.4),
-        lpSolveAPI (>= 5.5.2.0), parallel, grid
+Suggests: glpkAPI (>= 1.2.8), lpSolveAPI (>= 5.5.2.0), parallel, grid
 URL:
         https://www.cs.hhu.de/lehrstuehle-und-arbeitsgruppen/computational-cell-biology/software-contributions/sybil
 Description: This Systems Biology Package (Gelius-Dietrich et. al. (2012) <doi:10.1186/1752-0509-7-125>) implements algorithms for constraint based analyses of metabolic networks, e.g. flux-balance analysis (FBA), minimization of metabolic adjustment (MOMA), regulatory on/off minimization (ROOM), robustness analysis and flux variability analysis. The package is easily extendable for additional algorithms. Most of the current LP/MILP solvers are supported via additional packages.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,6 @@
+### Version 2.1.1 , dated 05-10-2022
+
+checking package dependencies ... NOTE
+Packages suggested but not available for checking: 'cplexAPI', 'clpAPI'
+
+Action: remove the suggested packages until the new versions of these packages are available on CRAN.


### PR DESCRIPTION
This PR aims to resolve the CRAN warning about the 2 packages that are not yet available on CRAN. Once they are, the 2 suggested packages should be added back.

_note: pinging @mro100 about this as well_